### PR TITLE
Fixed missing docs warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#![crate_name = "gfx_graphics"]
-#![deny(missing_doc)]
+#![deny(missing_docs)]
 #![feature(phase)]
 
 //! The implementation of a Rust-Graphics back-end using gfx-rs.


### PR DESCRIPTION
- Removed crate_name attribute, since this is specified in Cargo.toml
