### PR TITLE
Fixed the handle usage

### DIFF
--- a/src/back_end.rs
+++ b/src/back_end.rs
@@ -33,8 +33,8 @@ struct ParamsUV<R: gfx::Resources> {
 
 /// The data used for drawing 2D graphics.
 pub struct Gfx2d<R: gfx::Resources> {
-    buffer_pos: gfx::BufferHandle<R, f32>,
-    buffer_uv: gfx::BufferHandle<R, f32>,
+    buffer_pos: gfx::handle::Buffer<R, f32>,
+    buffer_uv: gfx::handle::Buffer<R, f32>,
     batch: gfx::batch::OwnedBatch<Params<R>>,
     batch_uv: gfx::batch::OwnedBatch<ParamsUV<R>>,
 }


### PR DESCRIPTION
Something is deeply broken in the configuration here, since the examples are trying to build gfx_graphics from the git address instead of using the real instance. Yet, the change has to go in.