### PR TITLE
Ported to rust-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: rust
+rust:
+  - nightly
+  - 1.0.0-beta.4
 before_install:
   - sudo add-apt-repository ppa:team-xbmc/ppa -y
   - sudo apt-get update -qq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-gfx_graphics"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["graphics", "2d", "gfx", "piston"]
 description = "A Gfx 2D back-end for the Piston game engine"
@@ -28,11 +28,7 @@ git = "https://github.com/pistondevelopers/gfx_texture"
 
 [dependencies.gfx]
 git = "https://github.com/gfx-rs/gfx-rs"
-#version = "0.2.0"
-
-[dependencies.gfx_macros]
-git = "https://github.com/gfx-rs/gfx_macros"
-#version = "0.1.7"
+#version = "0.4.0"
 
 [dependencies.freetype-rs]
 git = "https://github.com/PistonDevelopers/freetype-rs.git"

--- a/src/back_end.rs
+++ b/src/back_end.rs
@@ -10,26 +10,27 @@ const UV_COMPONENTS: usize = 2;
 // Needs to be improved on gfx-rs side.
 // For some reason, using ``*_COMPONENT` triggers some macros errors.
 
-#[vertex_format]
-struct PositionFormat { pos: [f32; 2] }
+gfx_vertex!( PositionFormat {
+    pos@ pos: [f32; 2],
+});
 
-#[vertex_format]
-struct ColorFormat { color: [f32; 4] }
+gfx_vertex!( ColorFormat {
+    color@ color: [f32; 4],
+});
 
-#[vertex_format]
-struct TexCoordsFormat { uv: [f32; 2] }
+gfx_vertex!( TexCoordsFormat {
+    uv@ uv: [f32; 2],
+});
 
-#[shader_param]
-struct Params<R: gfx::Resources> {
-    color: [f32; 4],
-    _dummy: PhantomData<R>,
-}
+gfx_parameters!( Params/ParamsLink {
+    color@ color: [f32; 4],
+});
 
-#[shader_param]
-struct ParamsUV<R: gfx::Resources> {
-    color: [f32; 4],
-    s_texture: gfx::shade::TextureParam<R>,
-}
+gfx_parameters!( ParamsUV/ParamsUVLink {
+    color@ color: [f32; 4],
+    s_texture@ texture: gfx::shade::TextureParam<R>,
+});
+
 
 /// The data used for drawing 2D graphics.
 pub struct Gfx2d<R: gfx::Resources> {
@@ -113,7 +114,7 @@ impl<R: gfx::Resources> Gfx2d<R> {
 
         let params = Params {
             color: [1.0; 4],
-            _dummy: PhantomData,
+            _r: PhantomData,
         };
         let mut batch = gfx::batch::OwnedBatch::new(
             mesh,
@@ -132,7 +133,7 @@ impl<R: gfx::Resources> Gfx2d<R> {
 
         let params_uv = ParamsUV {
             color: [1.0; 4],
-            s_texture: (tex_handle, Some(sampler))
+            texture: (tex_handle, Some(sampler))
         };
         let mut batch_uv = gfx::batch::OwnedBatch::new(
             mesh_uv,


### PR DESCRIPTION
It fails to build because:
  1. somehow, it tries to build itself from Git (master) as a dependency
  2. it depends on piston_window, which is a circular dependency

Otherwise, the changes should be good. They are backwards-compatible.