### PR TITLE
pub use glyph::Error as GlyphError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate shaders_graphics2d as shaders;
 pub use gfx_texture::*;
 
 pub use back_end::{ Gfx2d, GfxGraphics };
+pub use glyph::Error as GlyphError;
 pub use glyph::GlyphCache;
 
 mod back_end;


### PR DESCRIPTION
since `mod glyph;` is private, re-export its `pub enum Error` alongside the re-exported `GlyphCache`. Otherwise, it is impossible for someone to write wrapper functions that return `Result<GlyphCache,
glyph::Error>`, because the error's parent module is private.

(You may want to also rename the definition of `glyph::Error` itself, because it may improve the doc presentation of the situation.)