### PR TITLE
Updated crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-gfx_graphics"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["graphics", "2d", "gfx", "piston"]
 description = "A Gfx 2D back-end for the Piston game engine"


### PR DESCRIPTION
- Bumped to 0.15.0 since reexport of `GlyphError` might cause existing code
to break