### PR TITLE
Replace freetype with rusttype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "gfx_graphics"
 
 
 [dependencies]
-freetype-rs = "0.6.0"
+rusttype = "0.2.0"
 gfx = "0.10.1"
 piston-shaders_graphics2d = "0.2.0"
 piston-gfx_texture = "0.12.0"

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -74,6 +74,8 @@ impl<R, F> CharacterCache for GlyphCache<R, F> where
         size: FontSize,
         ch: char
     ) -> Character<'a, Self::Texture> {
+        let size = ((size as f32) * 1.333).round() as u32 ; // convert points to pixels
+        
         match self.data.entry((size, ch)) {
             //returning `into_mut()' to get reference with 'a lifetime
             Entry::Occupied(v) => {

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -87,7 +87,9 @@ impl<R, F> CharacterCache for GlyphCache<R, F> where
                 }
             }
             Entry::Vacant(v) => {
-                let glyph = self.font.glyph(ch).unwrap();
+                // fallback to glyph zero or U+FFFD if glyph is not present
+                let glyph = self.font.glyph(ch).unwrap_or(self.font.glyph(rt::Codepoint(0)).unwrap_or(self.font.glyph('\u{FFFD}').unwrap()));
+
                 let glyph = glyph.scaled(rt::Scale::uniform(size as f32));
                 let h_metrics = glyph.h_metrics();
                 let bounding_box = glyph.exact_bounding_box().unwrap_or(rt::Rect{min: rt::Point{x: 0.0, y: 0.0}, max: rt::Point{x: 0.0, y: 0.0} });


### PR DESCRIPTION
This is my try at replacing freetype with rusttype. It does not use the gpu cache implemented in rusttype.
Currently there are 2 open points:
- I am unsure about the size / offset logic, someone should review this.
- How to handle glyphs which are not in the font?

Additionally no kerning is applied and the line spacings are not taken from the font, this would require changes in the graphics crate.

Issue: #276 