### PR TITLE
Bump rusttype version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-gfx_graphics"
-version = "0.31.1"
+version = "0.31.2"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["graphics", "2d", "gfx", "piston"]
 description = "A Gfx 2D back-end for the Piston game engine"
@@ -17,7 +17,7 @@ name = "gfx_graphics"
 
 
 [dependencies]
-rusttype = "0.2.0"
+rusttype = "0.2.1"
 gfx = "0.12.0"
 draw_state = "0.6.0"
 piston-shaders_graphics2d = "0.2.1"


### PR DESCRIPTION
The previous rusttype version used an old version of ndarray that is
broken on the latest nightlies.