### PR TITLE
Fix bug causing text to be drawn 2 pixels off

### DIFF
--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -117,7 +117,7 @@ impl<R, F> CharacterCache for GlyphCache<R, F> where
 
                 let &mut (offset, size, ref texture) = v.insert((
                     [
-                        bounding_box.min.x as Scalar + 1.0,
+                        bounding_box.min.x as Scalar - 1.0,
                         -pixel_bounding_box.min.y as Scalar + 1.0,
                     ],
                     [


### PR DESCRIPTION
It appears that 1305ef86d266a4913e04183faaf16024b36d384f introduced a bug causing text to be drawn 2 pixels to the right of where it should be.